### PR TITLE
exclude ng prefix from unknown selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
     }],
     "indentation": 4,
     "selector-type-no-unknown": [true, {
-        "ignoreTypes": ["/^gfp-/"]
+        "ignoreTypes": ["/^gfp-/", "/^ng-/"]
     }]
   }
 }


### PR DESCRIPTION
Excludes `ng-` prefixed tags from the ‘unknown selector’ rule.
`ng-` prefixed tags are default AngularJS components and directives, like `<ng-transclude />`.